### PR TITLE
fix: when there are no changes (no diffgraph html is produced), display a 'no-changes' screen instead of throwing error

### DIFF
--- a/media/no-changes-screen.html
+++ b/media/no-changes-screen.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>No DiffGraph</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: var(--vscode-editor-background);
+            color: var(--vscode-foreground);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+
+        .no-changes-container {
+            text-align: center;
+            max-width: 300px;
+        }
+
+        .no-changes-title {
+            font-size: 16px;
+            font-weight: 500;
+            margin-bottom: 8px;
+            color: var(--vscode-foreground);
+        }
+
+        .wildest-logo {
+            font-size: 18px;
+            font-weight: bold;
+            color: var(--vscode-textLink-foreground);
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="no-changes-container">
+        <div class="wildest-logo">WildestAI</div>
+        <div class="no-changes-title">No changes</div>
+    </div>
+</body>
+
+</html>

--- a/src/services/DiffService.ts
+++ b/src/services/DiffService.ts
@@ -258,11 +258,17 @@ export class DiffService {
 	 * Shows the HTML content in the existing diffGraphView webview
 	 */
 	private async showWebviewWithContent(htmlFilePath: string, stage: string): Promise<void> {
-		if (this._diffGraphViewProvider) {
-			await this._diffGraphViewProvider.showDiffGraph(htmlFilePath);
-		} else {
+		if (!this._diffGraphViewProvider) {
 			vscode.window.showErrorMessage('DiffGraphView provider not available');
+			return;
 		}
+		// if htmlFilePath exists
+		if (!fs.existsSync(htmlFilePath)) {
+			// show no changes HTML
+			await this._diffGraphViewProvider.showNoChangesScreen();
+			return;
+		}
+		await this._diffGraphViewProvider.showDiffGraph(htmlFilePath);
 	}
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a static “No changes” screen with centered branding and message for empty results (new media page).

- Bug Fixes
  - Show a reliable fallback “No changes” screen when expected content is missing.
  - Improved error handling to ensure the view stays visible and responsive if loading fails.

- Refactor
  - Consolidated static screen rendering through a shared helper.
  - Streamlined the loading-screen path to use the common rendering flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->